### PR TITLE
Fix tilt dependency from ~> 2.0 to ~> 1.0

### DIFF
--- a/sidekiq-statistic.gemspec
+++ b/sidekiq-statistic.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'sidekiq', '>= 5.0'
-  gem.add_dependency 'tilt', '~> 2.0'
+  gem.add_dependency 'tilt', '~> 1.0'
 
   gem.add_development_dependency 'rake', '~> 0'
   gem.add_development_dependency 'mocha', '~> 0'


### PR DESCRIPTION
### Release Note

- Change the tilt dependent version from 2.0 to 1.0 to resolve the dependency of other gems